### PR TITLE
Changed the order of tasks to avoid apt missing key errors

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
+- apt_key:
+    url: http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
 - apt_repository:
     repo: 'deb http://packages.erlang-solutions.com/ubuntu {{ansible_lsb.codename}} contrib'
     state: present
-- apt_key:
-    url: http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
 - apt: update_cache=yes
 - apt: name={{ item }} state=present
   with_items:


### PR DESCRIPTION
Adding the key after the repo leads to key issues in ubuntu trusty64 and xenial64 based vagrant boxes. Fixed this issue by flipping apt_key and apt_repository tasks.
